### PR TITLE
feat: adding create agent UI for single prompt agent generation

### DIFF
--- a/components/AgentCreator.tsx
+++ b/components/AgentCreator.tsx
@@ -1,0 +1,502 @@
+import React, { useState, useRef, useEffect } from "react";
+import axios from "axios";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { materialDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  AgentCreatorProps,
+  ConversationMessage,
+  AgentGenerateRequest,
+  AgentGenerateResponse,
+  GenerationsListResponse,
+} from "../types";
+
+const AgentCreator: React.FC<AgentCreatorProps> = ({
+  baseUrl,
+  onAgentCreated,
+  projectId,
+}) => {
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [inputValue, setInputValue] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
+  const [createdAgent, setCreatedAgent] = useState<Record<string, any> | null>(
+    null
+  );
+  const [conversationHistory, setConversationHistory] = useState<
+    ConversationMessage[]
+  >([]);
+  const [deployedAgent, setDeployedAgent] = useState<Record<
+    string,
+    any
+  > | null>(null);
+  const [deployLoading, setDeployLoading] = useState<boolean>(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load conversation when projectId changes
+  useEffect(() => {
+    if (projectId) {
+      loadExistingConversation(projectId);
+    } else {
+      // Reset to welcome message for new conversation
+      setMessages([
+        {
+          role: "assistant",
+          content:
+            'Hello! I\'m here to help you create a new IntentKit agent. Just describe what you want your agent to do, and I\'ll help you build it step by step. For example:\n\n• "Create an agent that helps track crypto prices"\n• "I need an agent for managing my DeFi portfolio"\n• "Build an agent that can answer questions about blockchain data"\n\nWhat kind of agent would you like to create?',
+        },
+      ]);
+      setCurrentProjectId(null);
+      setCreatedAgent(null);
+      setDeployedAgent(null);
+    }
+  }, [projectId]);
+
+  const loadExistingConversation = async (projectId: string) => {
+    try {
+      const apiBaseUrl = baseUrl.replace("localhost", "127.0.0.1");
+
+      const response = await axios.get(
+        `${apiBaseUrl}/agent/generations/${projectId}`
+      );
+
+      const conversationData = response.data;
+
+      // Set the conversation history
+      if (conversationData.conversation_history) {
+        setMessages(conversationData.conversation_history);
+
+        // Find the last agent in the conversation (without reversing the original array)
+        const lastAgentMessage = [...conversationData.conversation_history]
+          .reverse()
+          .find((msg: ConversationMessage) => msg.metadata?.agent);
+
+        if (lastAgentMessage?.metadata?.agent) {
+          setCreatedAgent(lastAgentMessage.metadata.agent);
+        }
+      }
+
+      setCurrentProjectId(projectId);
+    } catch (error) {
+      console.error("Error loading conversation:", error);
+      // Fallback to welcome message if loading fails
+      setMessages([
+        {
+          role: "assistant",
+          content:
+            "Sorry, I couldn't load that conversation. Let's start fresh! What kind of agent would you like to create?",
+        },
+      ]);
+    }
+  };
+
+  // Scroll to bottom of messages
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  // Handle updates to message state
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputValue.trim() || loading) return;
+
+    const userMessage: ConversationMessage = {
+      role: "user",
+      content: inputValue,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    const currentInput = inputValue;
+    setInputValue("");
+    setLoading(true);
+
+    try {
+      // Convert localhost to 127.0.0.1 in the baseUrl
+      const apiBaseUrl = baseUrl.replace("localhost", "127.0.0.1");
+
+      // Prepare request payload
+      const requestPayload: AgentGenerateRequest = {
+        prompt: currentInput,
+        user_id: "sandbox-user", // make this dynamic later
+        project_id: currentProjectId || undefined,
+        existing_agent: createdAgent || undefined, // Include existing agent for modifications
+      };
+
+      console.log("Sending agent generation request:", requestPayload);
+
+      const response = await axios.post<AgentGenerateResponse>(
+        `${apiBaseUrl}/agent/generate`,
+        requestPayload
+      );
+
+      const { agent, project_id, summary, tags } = response.data;
+
+      // Update current project ID if it's new
+      if (!currentProjectId) {
+        setCurrentProjectId(project_id);
+      }
+
+      // Set the created agent
+      setCreatedAgent(agent);
+      console.log("Agent schema created:", agent);
+
+      // Add assistant response
+      const assistantMessage: ConversationMessage = {
+        role: "assistant",
+        content: summary,
+        metadata: {
+          agent: agent,
+          project_id: project_id,
+          tags: tags,
+        },
+      };
+
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (error) {
+      console.error("Error creating agent:", error);
+
+      let errorMessage = "Failed to create agent";
+      if (axios.isAxiosError(error)) {
+        if (error.response?.data?.detail) {
+          errorMessage = `Error: ${
+            error.response.data.detail.msg || error.response.data.detail
+          }`;
+        } else if (error.response?.data?.msg) {
+          errorMessage = `Error: ${error.response.data.msg}`;
+        } else if (error.message) {
+          errorMessage = `Error: ${error.message}`;
+        }
+      }
+
+      const errorMsg: ConversationMessage = {
+        role: "assistant",
+        content: errorMessage,
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  const renderMessage = (message: ConversationMessage, index: number) => {
+    const isUser = message.role === "user";
+
+    return (
+      <div
+        key={index}
+        className={`flex ${isUser ? "justify-end" : "justify-start"} mb-4`}
+      >
+        <div
+          className={`max-w-[80%] rounded-lg px-4 py-3 ${
+            isUser
+              ? "bg-[#0969da] text-white"
+              : "bg-[#161b22] border border-[#30363d] text-[#c9d1d9]"
+          }`}
+        >
+          <div className="whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+
+          {/* Show agent preview if this message contains agent data */}
+          {message.metadata?.agent && (
+            <div className="mt-4 p-3 bg-[#0d1117] rounded border border-[#21262d]">
+              <div className="text-sm font-medium text-[#58a6ff] mb-2">
+                ✨ Agent Created Successfully!
+              </div>
+              <div className="text-xs space-y-1">
+                <div>
+                  <span className="text-[#7d8590]">Name:</span>{" "}
+                  {message.metadata.agent.name || "Unnamed Agent"}
+                </div>
+                <div>
+                  <span className="text-[#7d8590]">Purpose:</span>{" "}
+                  {message.metadata.agent.purpose || "No purpose defined"}
+                </div>
+                <div>
+                  <span className="text-[#7d8590]">Model:</span>{" "}
+                  {message.metadata.agent.model || "Default"}
+                </div>
+                <div>
+                  <span className="text-[#7d8590]">Skills:</span>{" "}
+                  {Object.keys(message.metadata.agent.skills || {}).length >
+                  0 ? (
+                    <div className="mt-1">
+                      {Object.keys(message.metadata.agent.skills || {}).map(
+                        (skillName, index) => (
+                          <span
+                            key={skillName}
+                            className="inline-flex items-center bg-[#21262d] text-[#58a6ff] text-xs px-2 py-1 rounded mr-1 mb-1 group"
+                          >
+                            {skillName}
+                            <button
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                removeSkillFromAgent(skillName);
+                              }}
+                              className="ml-1 text-[#8b949e] hover:text-[#f85149] transition-colors opacity-0 group-hover:opacity-100"
+                              title={`Remove ${skillName} skill`}
+                            >
+                              ×
+                            </button>
+                          </span>
+                        )
+                      )}
+                    </div>
+                  ) : (
+                    "No skills configured"
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const renderTypingIndicator = () => {
+    return (
+      <div className="flex justify-start mb-4">
+        <div className="bg-[#161b22] border border-[#30363d] text-[#c9d1d9] rounded-lg px-4 py-3">
+          <div className="flex space-x-1">
+            <div className="w-2 h-2 bg-[#58a6ff] rounded-full animate-bounce"></div>
+            <div
+              className="w-2 h-2 bg-[#58a6ff] rounded-full animate-bounce"
+              style={{ animationDelay: "0.1s" }}
+            ></div>
+            <div
+              className="w-2 h-2 bg-[#58a6ff] rounded-full animate-bounce"
+              style={{ animationDelay: "0.2s" }}
+            ></div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const exportAgent = () => {
+    if (!createdAgent) return;
+
+    const dataStr = JSON.stringify(createdAgent, null, 2);
+    const dataUri =
+      "data:application/json;charset=utf-8," + encodeURIComponent(dataStr);
+
+    const exportFileDefaultName = `${createdAgent.name || "agent"}.json`;
+
+    const linkElement = document.createElement("a");
+    linkElement.setAttribute("href", dataUri);
+    linkElement.setAttribute("download", exportFileDefaultName);
+    linkElement.click();
+  };
+
+  const removeSkillFromAgent = (skillName: string) => {
+    console.log("Removing skill:", skillName);
+    console.log("Current createdAgent:", createdAgent);
+
+    if (!createdAgent || !createdAgent.skills) {
+      console.log("No created agent or skills found");
+      return;
+    }
+
+    // Create a copy of the agent without the specified skill
+    const updatedAgent = {
+      ...createdAgent,
+      skills: { ...createdAgent.skills },
+    };
+
+    // Remove the skill
+    delete updatedAgent.skills[skillName];
+
+    console.log("Updated agent after skill removal:", updatedAgent);
+
+    // Update the created agent
+    setCreatedAgent(updatedAgent);
+
+    // Update all existing messages that contain agent metadata to reflect the skill removal
+    setMessages((prevMessages) => {
+      return prevMessages.map((msg) => {
+        if (msg.metadata?.agent && msg.role === "assistant") {
+          return {
+            ...msg,
+            metadata: {
+              ...msg.metadata,
+              agent: updatedAgent,
+            },
+          };
+        }
+        return msg;
+      });
+    });
+
+    // Add a message to the chat showing the skill was removed
+    const removalMessage: ConversationMessage = {
+      role: "assistant",
+      content: `✅ Removed "${skillName}" skill from the agent. The agent schema has been updated.`,
+      metadata: {
+        agent: updatedAgent,
+        skillRemoved: skillName,
+      },
+    };
+
+    setMessages((prev) => [...prev, removalMessage]);
+  };
+
+  const deployAgent = async () => {
+    if (!createdAgent || deployLoading) return;
+
+    setDeployLoading(true);
+
+    try {
+      const apiBaseUrl = baseUrl.replace("localhost", "127.0.0.1");
+
+      // Get credentials from localStorage if available
+      const username = localStorage.getItem("intentkit_username");
+      const password = localStorage.getItem("intentkit_password");
+
+      const config: any = {};
+      if (username && password) {
+        config.auth = {
+          username,
+          password,
+        };
+      }
+
+      console.log("Deploying agent:", createdAgent);
+
+      const response = await axios.post(
+        `${apiBaseUrl}/agents`,
+        createdAgent,
+        config
+      );
+
+      setDeployedAgent(response.data);
+
+      // Add success message to chat
+      const successMessage: ConversationMessage = {
+        role: "assistant",
+        content: `🎉 Excellent! Your agent "${
+          createdAgent.name || "Unnamed Agent"
+        }" has been successfully deployed and is now ready to use! You can find it in the agents list on the main page.`,
+        metadata: {
+          deployedAgent: response.data,
+          success: true,
+        },
+      };
+
+      setMessages((prev) => [...prev, successMessage]);
+
+      // Call callback if provided
+      if (onAgentCreated) {
+        onAgentCreated(response.data);
+      }
+    } catch (error) {
+      console.error("Error deploying agent:", error);
+
+      let errorMessage = "Failed to deploy agent";
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          errorMessage =
+            "Authentication required. Please check your credentials in the main settings.";
+        } else if (error.response?.data?.detail) {
+          errorMessage = `Deployment Error: ${error.response.data.detail}`;
+        } else if (error.message) {
+          errorMessage = `Deployment Error: ${error.message}`;
+        }
+      }
+
+      const errorMsg: ConversationMessage = {
+        role: "assistant",
+        content: `❌ ${errorMessage}`,
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setDeployLoading(false);
+    }
+  };
+
+  console.log("Render - createdAgent:", createdAgent);
+  console.log("Render - deployedAgent:", deployedAgent);
+
+  return (
+    <div className="bg-[#0d1117] rounded-xl border border-[#30363d] h-full flex flex-col">
+      {/* Header */}
+      <div className="border-b border-[#30363d] p-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-[#c9d1d9]">
+            AI Agent Creator
+          </h2>
+          {createdAgent && (
+            <div className="flex space-x-2">
+              {!deployedAgent && (
+                <button
+                  onClick={deployAgent}
+                  disabled={deployLoading}
+                  className="text-sm py-1.5 px-3 bg-[#0969da] text-white rounded hover:bg-[#0550ae] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {deployLoading ? "Deploying..." : "🚀 Deploy Agent"}
+                </button>
+              )}
+              <button
+                onClick={exportAgent}
+                className="text-sm py-1.5 px-3 bg-[#238636] text-white rounded hover:bg-[#2ea043] transition-colors"
+              >
+                📥 Export Schema
+              </button>
+            </div>
+          )}
+        </div>
+        <p className="text-sm text-[#8b949e] mt-1">
+          {deployedAgent
+            ? "✅ Agent deployed successfully!"
+            : createdAgent
+            ? "Agent schema ready - deploy or export when satisfied"
+            : "Describe your agent and I'll help you create it"}
+        </p>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((message, index) => renderMessage(message, index))}
+        {loading && renderTypingIndicator()}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-[#30363d] p-4">
+        <form onSubmit={handleSubmit} className="flex space-x-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Describe the agent you want to create..."
+            className="flex-1 bg-[#161b22] border border-[#30363d] rounded-lg px-4 py-2 text-[#c9d1d9] placeholder-[#8b949e] focus:border-[#58a6ff] focus:outline-none"
+            disabled={loading}
+          />
+          <button
+            type="submit"
+            disabled={loading || !inputValue.trim()}
+            className="bg-[#238636] text-white px-4 py-2 rounded-lg hover:bg-[#2ea043] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? "Creating..." : "Send"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AgentCreator;

--- a/components/ConversationHistory.tsx
+++ b/components/ConversationHistory.tsx
@@ -1,0 +1,221 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import {
+  GenerationsListResponse,
+  ConversationProject,
+  ConversationMessage,
+} from "../types";
+
+interface ConversationHistoryProps {
+  baseUrl: string;
+  onProjectSelect?: (projectId: string) => void;
+}
+
+const ConversationHistory: React.FC<ConversationHistoryProps> = ({
+  baseUrl,
+  onProjectSelect,
+}) => {
+  const [projects, setProjects] = useState<ConversationProject[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [expandedProject, setExpandedProject] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchConversationHistory();
+  }, [baseUrl]);
+
+  const fetchConversationHistory = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const apiBaseUrl = baseUrl.replace("localhost", "127.0.0.1");
+      const response = await axios.get<GenerationsListResponse>(
+        `${apiBaseUrl}/agent/generations?limit=20`
+      );
+
+      setProjects(response.data.projects);
+    } catch (err) {
+      console.error("Error fetching conversation history:", err);
+      setError("Failed to fetch conversation history");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return (
+        date.toLocaleDateString() +
+        " " +
+        date.toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      );
+    } catch {
+      return dateString;
+    }
+  };
+
+  const getProjectTitle = (project: ConversationProject) => {
+    if (project.first_message?.content) {
+      // Extract first 50 characters of first user message
+      return (
+        project.first_message.content.slice(0, 50) +
+        (project.first_message.content.length > 50 ? "..." : "")
+      );
+    }
+    return `Conversation ${project.project_id.slice(0, 8)}`;
+  };
+
+  const toggleExpanded = (projectId: string) => {
+    setExpandedProject(expandedProject === projectId ? null : projectId);
+  };
+
+  const selectProject = (projectId: string) => {
+    setSelectedProject(projectId);
+    if (onProjectSelect) {
+      onProjectSelect(projectId);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-[#161b22] rounded-xl border border-[#30363d] p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-[#30363d] rounded w-1/3"></div>
+          <div className="space-y-2">
+            <div className="h-12 bg-[#30363d] rounded"></div>
+            <div className="h-12 bg-[#30363d] rounded"></div>
+            <div className="h-12 bg-[#30363d] rounded"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-[#161b22] rounded-xl border border-[#30363d] p-6">
+        <div className="text-center">
+          <div className="text-red-400 mb-2">⚠️ {error}</div>
+          <button
+            onClick={fetchConversationHistory}
+            className="text-sm py-1.5 px-3 bg-[#21262d] text-[#c9d1d9] rounded border border-[#30363d] hover:bg-[#30363d]"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#161b22] rounded-xl border border-[#30363d] h-full flex flex-col">
+      {/* Header */}
+      <div className="border-b border-[#30363d] p-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-[#c9d1d9]">
+            📝 Conversation History
+          </h2>
+          <button
+            onClick={fetchConversationHistory}
+            className="text-sm py-1.5 px-3 bg-[#21262d] text-[#c9d1d9] rounded border border-[#30363d] hover:bg-[#30363d]"
+          >
+            Refresh
+          </button>
+        </div>
+        <p className="text-sm text-[#8b949e] mt-1">
+          Your agent creation conversations
+        </p>
+      </div>
+
+      {/* Projects List */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {projects.length === 0 ? (
+          <div className="text-center text-[#8b949e] py-8">
+            <div className="text-4xl mb-4">🤖</div>
+            <div className="text-lg mb-2">No conversations yet</div>
+            <div className="text-sm">
+              Start creating agents to see your conversation history here
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {projects.map((project) => (
+              <div
+                key={project.project_id}
+                className={`border border-[#30363d] rounded-lg p-4 hover:border-[#58a6ff] transition-colors cursor-pointer ${
+                  selectedProject === project.project_id
+                    ? "border-[#58a6ff] bg-[#0d1117]"
+                    : ""
+                }`}
+                onClick={() => selectProject(project.project_id)}
+              >
+                <div className="flex justify-between items-start mb-2">
+                  <div className="flex-1">
+                    <h3 className="text-[#c9d1d9] font-medium text-sm">
+                      {getProjectTitle(project)}
+                    </h3>
+                    <div className="text-xs text-[#8b949e] mt-1 space-x-4">
+                      <span>Messages: {project.message_count}</span>
+                      <span>
+                        Last: {formatDate(project.last_activity || "")}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleExpanded(project.project_id);
+                    }}
+                    className="text-[#8b949e] hover:text-[#c9d1d9] p-1"
+                  >
+                    {expandedProject === project.project_id ? "−" : "+"}
+                  </button>
+                </div>
+
+                {expandedProject === project.project_id && (
+                  <div className="mt-3 pt-3 border-t border-[#30363d]">
+                    <div className="space-y-2 max-h-40 overflow-y-auto">
+                      {project.conversation_history
+                        .slice(0, 6)
+                        .map((message, idx) => (
+                          <div key={idx} className="text-xs">
+                            <span
+                              className={`font-medium ${
+                                message.role === "user"
+                                  ? "text-[#58a6ff]"
+                                  : "text-[#85e89d]"
+                              }`}
+                            >
+                              {message.role === "user" ? "You" : "Assistant"}:
+                            </span>
+                            <span className="text-[#c9d1d9] ml-2">
+                              {message.content.slice(0, 100)}
+                              {message.content.length > 100 ? "..." : ""}
+                            </span>
+                          </div>
+                        ))}
+                      {project.conversation_history.length > 6 && (
+                        <div className="text-xs text-[#8b949e] italic">
+                          ... {project.conversation_history.length - 6} more
+                          messages
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ConversationHistory;

--- a/pages/conversations.tsx
+++ b/pages/conversations.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import ConversationHistory from "../components/ConversationHistory";
+
+const ConversationsPage: React.FC = () => {
+  const [baseUrl, setBaseUrl] = useState<string>("http://127.0.0.1:8000");
+
+  // Check for stored base URL in localStorage
+  useEffect(() => {
+    const storedBaseUrl = localStorage.getItem("intentkit_base_url");
+    if (storedBaseUrl) {
+      setBaseUrl(storedBaseUrl);
+    }
+  }, []);
+
+  const handleProjectSelect = (projectId: string) => {
+    console.log("Selected project:", projectId);
+    // You could navigate to a detailed view or do something else with the selected project
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0d1117] flex flex-col h-screen">
+      <Head>
+        <title>Conversation History - IntentKit Sandbox</title>
+        <meta
+          name="description"
+          content="View your agent creation conversation history"
+        />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      {/* Header */}
+      <header className="bg-[#161b22] border-b border-[#30363d] py-3">
+        <div className="max-w-full mx-auto px-4 flex justify-between items-center">
+          <div className="flex items-center space-x-4">
+            <Link
+              href="/"
+              className="text-sm py-1.5 px-3 bg-[#21262d] text-[#c9d1d9] rounded border border-[#30363d] hover:bg-[#30363d] transition-colors"
+            >
+              ← Back to Sandbox
+            </Link>
+            <h1 className="text-xl font-bold text-[#c9d1d9]">
+              Conversation History
+            </h1>
+          </div>
+          <div className="flex items-center space-x-3">
+            <Link
+              href="/create-agent"
+              className="text-sm py-1.5 px-3 bg-[#238636] text-white rounded hover:bg-[#2ea043] transition-colors"
+            >
+              + Create New Agent
+            </Link>
+            <span className="text-sm text-[#8b949e]">
+              Connected to: {baseUrl}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-hidden">
+        <div className="max-w-6xl mx-auto h-full px-4 py-6">
+          <ConversationHistory
+            baseUrl={baseUrl}
+            onProjectSelect={handleProjectSelect}
+          />
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-[#161b22] border-t border-[#30363d] py-2">
+        <div className="max-w-full mx-auto px-4 text-center">
+          <p className="text-xs text-[#8b949e]">
+            IntentKit Conversation History
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default ConversationsPage;

--- a/pages/create-agent.tsx
+++ b/pages/create-agent.tsx
@@ -1,0 +1,235 @@
+import React, { useState, useEffect } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import axios from "axios";
+import AgentCreator from "../components/AgentCreator";
+import { GenerationsListResponse, ConversationProject } from "../types";
+
+const CreateAgentPage: React.FC = () => {
+  const router = useRouter();
+  const [baseUrl, setBaseUrl] = useState<string>("http://127.0.0.1:8000");
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [conversations, setConversations] = useState<ConversationProject[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+    null
+  );
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
+  const [loadingConversations, setLoadingConversations] =
+    useState<boolean>(true);
+
+  // Check for stored base URL in localStorage
+  useEffect(() => {
+    const storedBaseUrl = localStorage.getItem("intentkit_base_url");
+    if (storedBaseUrl) {
+      setBaseUrl(storedBaseUrl);
+    }
+  }, []);
+
+  // Load conversation history
+  useEffect(() => {
+    if (baseUrl) {
+      loadConversations();
+    }
+  }, [baseUrl]);
+
+  const loadConversations = async () => {
+    try {
+      setLoadingConversations(true);
+      const apiBaseUrl = baseUrl.replace("localhost", "127.0.0.1");
+
+      const response = await axios.get<GenerationsListResponse>(
+        `${apiBaseUrl}/agent/generations`
+      );
+
+      setConversations(response.data.projects || []);
+    } catch (error) {
+      console.error("Error loading conversations:", error);
+      setConversations([]);
+    } finally {
+      setLoadingConversations(false);
+    }
+  };
+
+  const handleAgentCreated = (agent: Record<string, any>) => {
+    console.log("Agent deployed successfully:", agent);
+    const agentName = agent.name || "Unnamed Agent";
+    setSuccessMessage(`🎉 Agent "${agentName}" deployed successfully!`);
+
+    // Reload conversations to show the updated list
+    loadConversations();
+
+    // Redirect to main page after 3 seconds to see the new agent
+    setTimeout(() => {
+      router.push("/");
+    }, 3000);
+  };
+
+  const handleNewConversation = () => {
+    setSelectedProjectId(null);
+  };
+
+  const handleSelectConversation = (projectId: string) => {
+    setSelectedProjectId(projectId);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffTime = Math.abs(now.getTime() - date.getTime());
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 1) return "Today";
+    if (diffDays === 2) return "Yesterday";
+    if (diffDays <= 7) return `${diffDays - 1} days ago`;
+    return date.toLocaleDateString();
+  };
+
+  const getConversationTitle = (conversation: ConversationProject) => {
+    if (conversation.first_message?.content) {
+      return (
+        conversation.first_message.content.slice(0, 50) +
+        (conversation.first_message.content.length > 50 ? "..." : "")
+      );
+    }
+    return `Conversation ${conversation.project_id.slice(0, 8)}`;
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0d1117] flex flex-col h-screen">
+      <Head>
+        <title>Create Agent - IntentKit Sandbox</title>
+        <meta
+          name="description"
+          content="Create a new IntentKit agent with AI assistance"
+        />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      {/* Header */}
+      <header className="bg-[#161b22] border-b border-[#30363d] py-3 flex-shrink-0">
+        <div className="max-w-full mx-auto px-4 flex justify-between items-center">
+          <div className="flex items-center space-x-4">
+            <button
+              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+              className="text-[#c9d1d9] hover:text-[#58a6ff] transition-colors p-1"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+              >
+                <path d="M1 2.75A.75.75 0 011.75 2h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 2.75zm0 5A.75.75 0 011.75 7h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 7.75zM1.75 12a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75z" />
+              </svg>
+            </button>
+            <Link
+              href="/"
+              className="text-sm py-1.5 px-3 bg-[#21262d] text-[#c9d1d9] rounded border border-[#30363d] hover:bg-[#30363d] transition-colors"
+            >
+              ← Back to Sandbox
+            </Link>
+            <h1 className="text-xl font-bold text-[#c9d1d9]">
+              Create New Agent
+            </h1>
+          </div>
+          <div className="flex items-center space-x-3">
+            {successMessage && (
+              <div className="text-green-400 text-sm font-medium py-1 px-2 bg-green-400/10 rounded border border-green-400/20">
+                {successMessage}
+              </div>
+            )}
+            <span className="text-sm text-[#8b949e]">
+              Connected to: {baseUrl}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* Main layout with sidebar */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <div
+          className={`bg-[#161b22] border-r border-[#30363d] flex-shrink-0 transition-all duration-300 ${
+            sidebarCollapsed ? "w-0" : "w-80"
+          } overflow-hidden`}
+        >
+          <div className="h-full flex flex-col">
+            {/* New conversation button */}
+            <div className="p-4 border-b border-[#30363d]">
+              <button
+                onClick={handleNewConversation}
+                className="w-full text-sm py-2 px-3 bg-[#238636] text-white rounded hover:bg-[#2ea043] transition-colors flex items-center justify-center space-x-2"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                >
+                  <path d="M7.75 2a.75.75 0 01.75.75V7h4.25a.75.75 0 010 1.5H8.5v4.25a.75.75 0 01-1.5 0V8.5H2.75a.75.75 0 010-1.5H7V2.75A.75.75 0 017.75 2z" />
+                </svg>
+                <span>New Conversation</span>
+              </button>
+            </div>
+
+            {/* Conversations list */}
+            <div className="flex-1 overflow-y-auto">
+              {loadingConversations ? (
+                <div className="p-4 text-center text-[#8b949e]">
+                  Loading conversations...
+                </div>
+              ) : conversations.length === 0 ? (
+                <div className="p-4 text-center text-[#8b949e]">
+                  No conversations yet
+                </div>
+              ) : (
+                <div className="p-2">
+                  {conversations.map((conversation) => (
+                    <button
+                      key={conversation.project_id}
+                      onClick={() =>
+                        handleSelectConversation(conversation.project_id)
+                      }
+                      className={`w-full text-left p-3 rounded mb-2 transition-colors ${
+                        selectedProjectId === conversation.project_id
+                          ? "bg-[#0969da] text-white"
+                          : "hover:bg-[#21262d] text-[#c9d1d9]"
+                      }`}
+                    >
+                      <div className="text-sm font-medium truncate">
+                        {getConversationTitle(conversation)}
+                      </div>
+                      <div className="text-xs text-[#8b949e] mt-1">
+                        {conversation.last_activity &&
+                          formatDate(conversation.last_activity)}
+                        {conversation.message_count && (
+                          <span className="ml-2">
+                            {conversation.message_count} messages
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Main content */}
+        <main className="flex-1 overflow-hidden">
+          <div className="h-full">
+            <AgentCreator
+              baseUrl={baseUrl}
+              onAgentCreated={handleAgentCreated}
+              projectId={selectedProjectId}
+            />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default CreateAgentPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
+import Link from "next/link";
 import ChatInterface from "../components/ChatInterface";
 import AgentsList from "../components/AgentsList";
 import AgentDetail from "../components/AgentDetail";
@@ -111,6 +112,12 @@ const Home: React.FC = () => {
             IntentKit Sandbox
           </h1>
           <div className="flex items-center space-x-3">
+            <Link
+              href="/create-agent"
+              className="text-sm py-1.5 px-3 bg-[#238636] text-white rounded hover:bg-[#2ea043] transition-colors"
+            >
+              + Create Agent
+            </Link>
             {selectedAgent && (
               <button
                 onClick={toggleViewMode}

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,6 +19,55 @@ export interface Skill {
   [key: string]: any; // For any additional properties
 }
 
+// Agent Generation API types
+export interface AgentGenerateRequest {
+  prompt: string;
+  existing_agent?: any;
+  user_id?: string;
+  project_id?: string;
+}
+
+export interface AgentGenerateResponse {
+  agent: Record<string, any>;
+  project_id: string;
+  summary: string;
+  tags: Array<{ id: number }>;
+}
+
+export interface ConversationMessage {
+  id?: string;
+  role: 'user' | 'assistant';
+  content: string;
+  metadata?: Record<string, any>;
+  created_at?: string;
+}
+
+export interface ConversationProject {
+  project_id: string;
+  user_id?: string;
+  created_at?: string;
+  last_activity?: string;
+  message_count: number;
+  last_message?: ConversationMessage;
+  first_message?: ConversationMessage;
+  conversation_history: ConversationMessage[];
+}
+
+export interface GenerationsListResponse {
+  projects: ConversationProject[];
+}
+
+export interface GenerationDetailResponse {
+  project_id: string;
+  user_id?: string;
+  created_at?: string;
+  last_activity?: string;
+  message_count: number;
+  last_message?: ConversationMessage;
+  first_message?: ConversationMessage;
+  conversation_history: ConversationMessage[];
+}
+
 // Component props
 export interface AgentsListProps {
   baseUrl: string;
@@ -38,6 +87,12 @@ export interface ChatInterfaceProps {
 export interface SettingsProps {
   baseUrl: string;
   onBaseUrlChange: (url: string) => void;
+}
+
+export interface AgentCreatorProps {
+  baseUrl: string;
+  onAgentCreated?: (agent: Record<string, any>) => void;
+  projectId?: string | null;
 }
 
 // Message types for chat


### PR DESCRIPTION
## Description
Just cooked up something pretty cool for the intentkit-sandbox-ui, a complete agent creation UI that feels exactly like ChatGPT! :rocket:

What makes it awesome?
- Left sidebar with conversation history, collapsible design, and chat interface that users already know and love
- Continue previous agent creation sessions, messages stay in proper order, and context is preserved
- Real-time agent schema generation with live previews
- Click to remove skills with × buttons
- Deploy button appears when you're happy with the schema
- See agent name, purpose, model, and individual skill badges
- All conversations saved to database, accessible anytime


https://github.com/user-attachments/assets/3202aed1-8f52-49ca-ac33-6a4a4c7cfbca



## Type of Changes

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Requirements

Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
